### PR TITLE
Add roles/dataproc.editor for kubeflow user account

### DIFF
--- a/deployment/gke/deployment_manager_configs/iam_bindings_template.yaml
+++ b/deployment/gke/deployment_manager_configs/iam_bindings_template.yaml
@@ -26,6 +26,7 @@ bindings:
   - roles/storage.admin
   - roles/bigquery.admin
   - roles/dataflow.admin
+  - roles/dataproc.editor
 - members:
   - set-kubeflow-vm-service-account
   roles:


### PR DESCRIPTION
Pipeline needs the dataproc editor permission to run the xgboost dataproc samples 
For details, see 
https://github.com/kubeflow/pipelines/tree/master/components/dataproc